### PR TITLE
Demonstrate dependency updates

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>26.0-jre</version>
+            <version>29.0-jre</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.6.RELEASE</version>
+        <version>1.5.22.RELEASE</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
@@ -19,7 +19,7 @@
     </modules>
 
     <properties>
-        <guava.version>25.0-jre</guava.version>
+        <guava.version>29.0-jre</guava.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This pull request demonstrates a few common types of Java Maven dependency upgrades using Rewrite's version selection rules. The changes are based on this recipe definition:

```yml
---
type: specs.openrewrite.org/v1beta/visitor
## this is a name that a user defines and can refer to in a recipe
name: com.usemoderne.dependencies.Guava
visitors:
  - org.openrewrite.maven.UpgradeVersion:
      groupId: com.google.guava
      toVersion: 25-30
      metadataPattern: '-jre'
---
type: specs.openrewrite.org/v1beta/visitor
name: com.usemoderne.dependencies.SpringBoot
visitors:
  - org.openrewrite.maven.UpgradeParentVersion:
      groupId: org.springframework.boot
      artifactId: spring-boot-starter-parent
      toVersion: 1.5.X

---
type: specs.openrewrite.org/v1beta/recipe
name: com.usemoderne.SampleMavenDependencies
include:
  - 'com.usemoderne.dependencies.*'
```

Contrast this with something like Dependabot which opens one PR per dependency and always selects the latest. Major and even minor version updates can be far riskier:

![image](https://user-images.githubusercontent.com/1697736/91612947-5bbdf100-e933-11ea-9d64-6ff71a207290.png)


